### PR TITLE
use scribe for logging + set logging username and password

### DIFF
--- a/consoleService.js
+++ b/consoleService.js
@@ -1,0 +1,28 @@
+var scribeConsole = function(tag, colors, _console) {
+  colors = colors ? colors : 'red';
+  return {
+    log: function(text) {
+      _console.time().tag({msg: tag, colors: colors})
+            .info(text);
+    },
+    error: function(text) {
+      _console.time().tag({msg: tag, colors: colors})
+            .error(text);
+    },
+    warn: function(text) {
+      _console.time().tag({msg: tag, colors: colors})
+            .warn(text);
+    },
+    info: function(text) {
+      _console.time().tag({msg: tag, colors: colors})
+            .info(text);
+    },
+    debug: function(text) {
+      _console.time().tag({msg: tag, colors: colors})
+            .debug(text);
+    },
+    customConsole: _console
+  };
+};
+
+module.exports = scribeConsole;

--- a/eventManager.js
+++ b/eventManager.js
@@ -6,6 +6,7 @@ var schema = require('js-schema');
 var async = require("async");
 var achievibitDB = require('./achievibitDB');
 var utilities = require('./utilities');
+var console = require('./consoleService')('GITHUB-EVENTS', ['blue', 'inverse'], process.console);
 var nconf = require('nconf');
 
 nconf.argv().env();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "gulp": "^3.9.1",
     "gulp-util": "^3.0.7",
     "helmet": "^3.1.0",
+    "http-auth": "^3.1.1",
     "js-schema": "^1.0.1",
     "lodash": "^4.16.6",
     "moment": "^2.15.2",


### PR DESCRIPTION
now achievibit supports username and password params for logging authentication.

this can be set by `--logsUsername` and `--logsPassword`

if no username and password are given, logs will be available without authentication at `<url-to-server>/logs`