### PR TITLE
add all basic data on merge event

### DIFF
--- a/achievibitDB.js
+++ b/achievibitDB.js
@@ -26,6 +26,8 @@ var collections = {
   users: db.get('users')
 };
 
+var apiUrl = 'https://api.github.com/repos/';
+
 var achievibitDB = {};
 
 initCollections();

--- a/achievibitDB.js
+++ b/achievibitDB.js
@@ -26,8 +26,6 @@ var collections = {
   users: db.get('users')
 };
 
-var apiUrl = 'https://api.github.com/repos/';
-
 var achievibitDB = {};
 
 initCollections();

--- a/eventManager.js
+++ b/eventManager.js
@@ -213,35 +213,35 @@ var EventManager = function() {
 
     // CODE REVIEW
 
-    if (_.isEqual(githubEvent, 'pull_request') &&
-            _.isEqual(eventData.action, 'review_requested')) {
-
-      utilities.mergeBasePRData(pullRequests, eventData);
-      var reviewer = utilities.parseUser(eventData.requested_reviewer);
-
-      if (!pullRequests[id].reviewers) {
-        pullRequests[id].reviewers = [];
-      }
-
-      pullRequests[id].reviewers.push(reviewer);
-    }
-
-    if (_.isEqual(githubEvent, 'pull_request') &&
-            _.isEqual(eventData.action, 'review_request_removed')) {
-
-      var reviewer = utilities.parseUser(eventData.requested_reviewer);
-
-      if (!pullRequests[id].reviewers) {
-        pullRequests[id].reviewers = [];
-      }
-
-      pullRequests[id].reviewers.push(reviewer);
-    }
-
-    if (_.isEqual(githubEvent, 'pull_request_review_comment') &&
-            _.isEqual(eventData.action, 'created')) {
-            //self.emit('open', eventData);
-    }
+    // if (_.isEqual(githubEvent, 'pull_request') &&
+    //         _.isEqual(eventData.action, 'review_requested')) {
+    //
+    //   utilities.mergeBasePRData(pullRequests, eventData);
+    //   var reviewer = utilities.parseUser(eventData.requested_reviewer);
+    //
+    //   if (!pullRequests[id].reviewers) {
+    //     pullRequests[id].reviewers = [];
+    //   }
+    //
+    //   pullRequests[id].reviewers.push(reviewer);
+    // }
+    //
+    // if (_.isEqual(githubEvent, 'pull_request') &&
+    //         _.isEqual(eventData.action, 'review_request_removed')) {
+    //
+    //   var reviewer = utilities.parseUser(eventData.requested_reviewer);
+    //
+    //   if (!pullRequests[id].reviewers) {
+    //     pullRequests[id].reviewers = [];
+    //   }
+    //
+    //   pullRequests[id].reviewers.push(reviewer);
+    // }
+    //
+    // if (_.isEqual(githubEvent, 'pull_request_review_comment') &&
+    //         _.isEqual(eventData.action, 'created')) {
+    //         //self.emit('open', eventData);
+    // }
 
         /**
          * PULL REQUEST ACHIEVEMENTS EVENTS


### PR DESCRIPTION
in case the open pull request event was skipped for some reason (like the server re-deploying)

things like `organization` weren't parsed since they were added on `open` event. If that event got lost, we didn't have an organization when checking achievement in `merge` event.


now, all the general PR data is taken again when we merge