### PR TITLE
[DO NOT SUBMIT] redirect all requests from http to https on production

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ var io = {};
 var publicFolder = __dirname + '/public';
 
 var token = nconf.get('ngrokToken');
+var env = nconf.get('env');
 
 // assign the swig engine to .html files
 app.engine('html', cons.swig);
@@ -137,6 +138,15 @@ app.post('/sendFakeAchievementNotification/:username',
       message: 'b33p b33p! faked a socket.io update'
     });
   });
+
+/**  ===============
+ *   = FORCE HTTPS =
+ *   = =============
+ *   on production, redirect all http requests to https
+ */
+if (env === 'production') {
+  app.all('*', ensureSecure);
+}
 
 /** ==================
  *   = ROUTES FOR API =
@@ -400,4 +410,15 @@ if (token) {
       ].join(''));
     }
   });
+}
+
+// Redirect all HTTP traffic to HTTPS (through heroku)
+function ensureSecure(req, res, next) {
+  if(req.headers["x-forwarded-proto"] === "https") {
+    // already secured. continue as normal
+    return next();
+  }
+  
+  // redirect the request to https
+  res.redirect('https://'+req.hostname+req.url);
 }

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,15 @@
+{
+  "short_name": "achievibit",
+  "name": "achievibit",
+  "icons": [
+    {
+      "src":"images/favicon.png",
+      "sizes": "250x250",
+      "type": "image/png"
+    }
+  ],
+  "start_url": "https://achievibit.herokuapp.com/?utm_source=homescreen",
+  "background_color": "#5A6384",
+  "theme_color": "#F2E8C4",
+  "display": "standalone"
+}

--- a/views/index.html
+++ b/views/index.html
@@ -16,6 +16,8 @@
   <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
   <link href="materialize.css" type="text/css" rel="stylesheet" media="screen,projection"/>
   <link href="style.css" type="text/css" rel="stylesheet" media="screen,projection"/>
+  <!-- MANIFEST -->
+  <link rel="manifest" href="/manifest.json">
 </head>
 <body>
   <nav class="white" role="navigation">


### PR DESCRIPTION
# Change Summary

 - made all `http` requests redirect to `https` if accessing `achievibit` on `heroku`
    >did this to comply with [this audit](https://developers.google.com/web/tools/lighthouse/audits/http-redirects-to-https)
 
## More info

This thing is part of a process to try and support offline access to our site and pass the [lighthouse inspection](https://chrome.google.com/webstore/detail/lighthouse/blipmdconlkpinefehnmjammfjpmpbjk)
