### PR TITLE
[FEATURE] Add review webhooks

### DIFF
--- a/achievibitDB.js
+++ b/achievibitDB.js
@@ -363,13 +363,7 @@ function getExtraPRData(pullRequest, givenCallback) {
         var reactionsRequests = [];
 
         _.forEach(comments, function(comment) {
-          var commentParsed = {
-            author: utilities.parseUser(comment.user),
-            message: comment.body,
-            createdOn: comment.created_at,
-            edited: !_.isEqual(comment.created_at, comment.updated_at),
-            apiUrl: comment.url
-          };
+          var commentParsed = utilities.parseComment(comment);
           pullRequest.comments.push(commentParsed);
 
           reactionsRequests.push(getReactions(commentParsed));
@@ -395,19 +389,8 @@ function getExtraPRData(pullRequest, givenCallback) {
         var reactionsRequests = [];
 
         _.forEach(inlineComments, function(inlineComment) {
-          var inlineCommentParsed = {
-            file: inlineComment.path,
-            author: utilities.parseUser(inlineComment.user),
-            message: inlineComment.body,
-            createdOn: inlineComment.created_at,
-            edited: !_.isEqual(
-              inlineComment.created_at,
-              inlineComment.updated_at
-            ),
-            commit: inlineComment.commit_id,
-            apiUrl: inlineComment.url
-
-          };
+          var inlineCommentParsed =
+            utilities.parseComment(inlineComment, true /* isInlineComment */);
           pullRequest.inlineComments.push(inlineCommentParsed);
           reactionsRequests.push(getReactions(inlineCommentParsed));
         });

--- a/eventManager.js
+++ b/eventManager.js
@@ -242,6 +242,31 @@ var EventManager = function() {
     }
 
     /**
+     * UPDATE PULL REQUEST DATA - REVIEWER DELETED COMMENT
+     * (as part of the CR)
+     */
+    if (_.isEqual(githubEvent, 'pull_request_review_comment') &&
+            _.isEqual(eventData.action, 'deleted')) {
+      utilities.mergeBasePRData(pullRequests, eventData);
+      // need to parse this and add to pull request data
+      var deletedReviewComment = utilities.parseComment(eventData.comment);
+      console.log('DELETED REVIEW COMMENT', deletedReviewComment);
+    }
+
+    /**
+     * UPDATE PULL REQUEST DATA - REVIEWER EDITED COMMENT
+     * (as part of the CR)
+     */
+    if (_.isEqual(githubEvent, 'pull_request_review_comment') &&
+            _.isEqual(eventData.action, 'edited')) {
+      utilities.mergeBasePRData(pullRequests, eventData);
+      // need to parse this and add to pull request data
+      var updatedReviewComment = utilities.parseComment(eventData.comment);
+      var oldBodyValue = eventData.changes.body.from;
+      console.log('EDITED REVIEW COMMENT', updatedReviewComment, oldBodyValue);
+    }
+
+    /**
      * UPDATE PULL REQUEST DATA - REVIEW SUBMITTED
      */
     if (_.isEqual(githubEvent, 'pull_request_review') &&

--- a/eventManager.js
+++ b/eventManager.js
@@ -40,10 +40,10 @@ var EventManager = function() {
   var self = this;
 
   self.notifyAchievements = function(githubEvent, eventData, io) {
-        /**
-         * NEW REPO CONNECTED!!!
-         * a repo added achievibit as a GitHub webhook!
-         */
+    /**
+     * NEW REPO CONNECTED!!!
+     * a repo added achievibit as a GitHub webhook!
+     */
     if (_.isEqual(githubEvent, 'ping')) {
       var repo = utilities.parseRepo(eventData.repository);
 
@@ -55,15 +55,15 @@ var EventManager = function() {
       achievibitDB.insertItem('repos', repo);
     }
 
-        /**
-         * INIT PULL REQUEST DATA
-         * Get the data as it was when the pull request opened.
-         * This will allow us to notify the achievements if something changed
-         * in case some achievements want to deal with changing things.
-         * notice that labels are given as a different event with the same
-         * time, so that way we know if that was an added label at creation
-         * or later
-         */
+    /**
+     * INIT PULL REQUEST DATA
+     * Get the data as it was when the pull request opened.
+     * This will allow us to notify the achievements if something changed
+     * in case some achievements want to deal with changing things.
+     * notice that labels are given as a different event with the same
+     * time, so that way we know if that was an added label at creation
+     * or later
+     */
     if (_.isEqual(githubEvent, 'pull_request') &&
             //_.isEqual(eventData.action, 'reopened') ?
             _.isEqual(eventData.action, 'opened')) {
@@ -77,12 +77,12 @@ var EventManager = function() {
       ].join(''), pullRequests[id]);
     }
 
-        /**
-         * INIT PULL REQUEST DATA - LABELS
-         * This event means a label was added on creation.
-         * Therefore, we'll add that to the pull request without
-         * adding an update event
-         */
+    /**
+     * INIT PULL REQUEST DATA - LABELS
+     * This event means a label was added on creation.
+     * Therefore, we'll add that to the pull request without
+     * adding an update event
+     */
     if (_.isEqual(githubEvent, 'pull_request') &&
             _.isEqual(eventData.action, 'labeled') &&
             _.isEqual(
@@ -97,9 +97,9 @@ var EventManager = function() {
 
       console.log('added labels on creation', pullRequests[id]);
 
-        /**
-         * UPDATE PULL REQUEST DATA - LABEL ADDED
-         */
+    /**
+     * UPDATE PULL REQUEST DATA - LABEL ADDED
+     */
     } else if (_.isEqual(githubEvent, 'pull_request') &&
             _.isEqual(eventData.action, 'labeled')) {
             /////
@@ -119,9 +119,9 @@ var EventManager = function() {
       console.log('UPDATE labels', pullRequests[id]);
     }
 
-        /**
-         * UPDATE PULL REQUEST DATA - LABEL REMOVED
-         */
+    /**
+     * UPDATE PULL REQUEST DATA - LABEL REMOVED
+     */
     if (_.isEqual(githubEvent, 'pull_request') &&
             _.isEqual(eventData.action, 'unlabeled')) {
             /////
@@ -143,12 +143,12 @@ var EventManager = function() {
       console.log('UPDATE labels', pullRequests[id]);
     }
 
-        /**
-         * UPDATE PULL REQUEST DATA - PULL REQUEST EDITED
-         * This means something changed:
-         *  * title
-         *  * description
-         */
+    /**
+     * UPDATE PULL REQUEST DATA - PULL REQUEST EDITED
+     * This means something changed:
+     *  * title
+     *  * description
+     */
     if (_.isEqual(githubEvent, 'pull_request') &&
             _.isEqual(eventData.action, 'edited')) {
             /////
@@ -189,11 +189,11 @@ var EventManager = function() {
 
     }
 
-        /**
-         * UPDATE PULL REQUEST DATA - ASSIGNEES CHANGED
-         * Currently, we don't log this change. But we can do that if we'll
-         * have some ideas for achievemenets for that :-)
-         */
+    /**
+     * UPDATE PULL REQUEST DATA - ASSIGNEES CHANGED
+     * Currently, we don't log this change. But we can do that if we'll
+     * have some ideas for achievemenets for that :-)
+     */
     if (_.isEqual(githubEvent, 'pull_request') &&
             (_.isEqual(eventData.action, 'unassigned') ||
             _.isEqual(eventData.action, 'assigned'))) {
@@ -213,42 +213,63 @@ var EventManager = function() {
 
     // CODE REVIEW
 
-    // if (_.isEqual(githubEvent, 'pull_request') &&
-    //         _.isEqual(eventData.action, 'review_requested')) {
-    //
-    //   utilities.mergeBasePRData(pullRequests, eventData);
-    //   var reviewer = utilities.parseUser(eventData.requested_reviewer);
-    //
-    //   if (!pullRequests[id].reviewers) {
-    //     pullRequests[id].reviewers = [];
-    //   }
-    //
-    //   pullRequests[id].reviewers.push(reviewer);
-    // }
-    //
-    // if (_.isEqual(githubEvent, 'pull_request') &&
-    //         _.isEqual(eventData.action, 'review_request_removed')) {
-    //
-    //   var reviewer = utilities.parseUser(eventData.requested_reviewer);
-    //
-    //   if (!pullRequests[id].reviewers) {
-    //     pullRequests[id].reviewers = [];
-    //   }
-    //
-    //   pullRequests[id].reviewers.push(reviewer);
-    // }
-    //
-    // if (_.isEqual(githubEvent, 'pull_request_review_comment') &&
-    //         _.isEqual(eventData.action, 'created')) {
-    //         //self.emit('open', eventData);
-    // }
+    /**
+     * UPDATE PULL REQUEST DATA - REVIEWER ADDED (review request)
+     */
+    if (_.isEqual(githubEvent, 'pull_request') &&
+            _.isEqual(eventData.action, 'review_requested')) {
 
-        /**
-         * PULL REQUEST ACHIEVEMENTS EVENTS
-         * Send correct events based on data
-         * so achievements can listen and UNLOCK if
-         * data matched what they looked for
-         */
+      utilities.mergeBasePRData(pullRequests, eventData);
+      var reviewer = utilities.parseUser(eventData.requested_reviewer);
+      console.log('ADDED REVIEWER', reviewer);
+      // if (!pullRequests[id].reviewers) {
+      //   pullRequests[id].reviewers = [];
+      // }
+      //
+      // pullRequests[id].reviewers.push(reviewer);
+    }
+
+    /**
+     * UPDATE PULL REQUEST DATA - REVIEWER COMMENTED
+     * (as part of the CR)
+     */
+    if (_.isEqual(githubEvent, 'pull_request_review_comment') &&
+            _.isEqual(eventData.action, 'created')) {
+      utilities.mergeBasePRData(pullRequests, eventData);
+      // need to parse this and add to pull request data
+      var newReviewComment = utilities.parseComment(eventData.comment);
+      console.log('NEW REVIEW COMMENT', newReviewComment);
+    }
+
+    /**
+     * UPDATE PULL REQUEST DATA - REVIEW SUBMITTED
+     */
+    if (_.isEqual(githubEvent, 'pull_request_review') &&
+            _.isEqual(eventData.action, 'submitted')) {
+
+      var newReviewStatus = utilities.parseReviewStatus(eventData.review);
+      console.log('NEW REVIEW STATUS RECIEVED', newReviewStatus);
+    }
+
+    /**
+     * UPDATE PULL REQUEST DATA - REVIEWER REMOVED
+     * Can we know who removed the reviewer?
+     */
+    if (_.isEqual(githubEvent, 'pull_request') &&
+            _.isEqual(eventData.action, 'review_request_removed')) {
+
+      var removedReviewer = utilities.parseUser(eventData.requested_reviewer);
+      console.log('REMOVED REVIEWER', removedReviewer);
+
+      // remove reviewer from reviewer's list, and add to removed list
+    }
+
+    /**
+     * PULL REQUEST ACHIEVEMENTS EVENTS
+     * Send correct events based on data
+     * so achievements can listen and UNLOCK if
+     * data matched what they looked for
+     */
     if (_.isEqual(githubEvent, 'pull_request') &&
             _.isEqual(eventData.action, 'closed') &&
             eventData.pull_request.merged) {

--- a/test/utilities.js
+++ b/test/utilities.js
@@ -47,7 +47,9 @@ describe('achievibit Utilities', function() {
   describe('getPullRequestIdFromEventData', function() {
     it('should create an id string out of GitHub\'s eventData', function() {
       var eventData = {
-        number: 1,
+        'pull_request': {
+          number: 1
+        },
         repository: {
           'full_name': 'repo'
         }

--- a/utilities.js
+++ b/utilities.js
@@ -13,6 +13,7 @@ utilities.initializePullRequest = initializePullRequest;
 utilities.mergeBasePRData = mergeBasePRData;
 utilities.parseReviewStatus = parseReviewStatus;
 utilities.parseComment = parseComment;
+utilities.parseReviewComment = parseReviewComment;
 
 module.exports = utilities;
 
@@ -44,9 +45,9 @@ function initializePullRequest(eventData) {
 
   if (eventData.pull_request.assignees) {
     var assignees = eventData.pull_request.assignees;
-    pullRequest.reviewers = [];
+    pullRequest.assignees = [];
     for (var i = 0; i < assignees.length; i++) {
-      pullRequest.reviewers.push(utilities.parseUser(assignees[i]));
+      pullRequest.assignees.push(utilities.parseUser(assignees[i]));
     }
   }
 
@@ -75,6 +76,22 @@ function parseComment(comment, isInlineComment) {
     commentObject.commit = comment.commit_id;
     commentObject.apiUrl = comment.url;
   }
+
+  return commentObject;
+}
+
+function parseReviewComment(comment) {
+  var commentObject = {
+    id: comment.id,
+    reviewId: comment.pull_request_review_id,
+    author: utilities.parseUser(comment.user),
+    message: comment.body,
+    createdOn: comment.created_at,
+    edited: !_.isEqual(comment.created_at, comment.updated_at),
+    apiUrl: comment.url,
+    file: comment.path,
+    commit: comment.commit_id
+  };
 
   return commentObject;
 }
@@ -141,7 +158,11 @@ function getNewFileFromPatch(patch) {
 }
 
 function getPullRequestIdFromEventData(eventData) {
-  return eventData.repository.full_name + '/pull/' + eventData.number;
+  return [
+    eventData.repository.full_name,
+    '/pull/',
+    eventData.pull_request.number
+  ].join('');
 }
 
 function mergeBasePRData(pullRequestsObject, eventData) {
@@ -150,5 +171,8 @@ function mergeBasePRData(pullRequestsObject, eventData) {
   if (!pullRequestsObject[id]) {
     pullRequestsObject[id] = {};
   }
-  _.assign(pullRequestsObject[id], utilities.initializePullRequest(eventData));
+
+  var newData = utilities.initializePullRequest(eventData);
+
+  _.assign(pullRequestsObject[id], newData);
 }

--- a/utilities.js
+++ b/utilities.js
@@ -11,6 +11,8 @@ utilities.isPullRequestAssociatedWithOrganization =
   isPullRequestAssociatedWithOrganization;
 utilities.initializePullRequest = initializePullRequest;
 utilities.mergeBasePRData = mergeBasePRData;
+utilities.parseReviewStatus = parseReviewStatus;
+utilities.parseComment = parseComment;
 
 module.exports = utilities;
 
@@ -56,6 +58,35 @@ function parseRepo(repository) {
     name: repository.name,
     fullname: repository.full_name,
     url: repository.html_url
+  };
+}
+
+function parseComment(comment, isInlineComment) {
+  var commentObject = {
+    author: utilities.parseUser(comment.user),
+    message: comment.body,
+    createdOn: comment.created_at,
+    edited: !_.isEqual(comment.created_at, comment.updated_at),
+    apiUrl: comment.url
+  };
+
+  if (isInlineComment) {
+    commentObject.file = comment.path;
+    commentObject.commit = comment.commit_id;
+    commentObject.apiUrl = comment.url;
+  }
+
+  return commentObject;
+}
+
+function parseReviewStatus(review) {
+  return {
+    id: review.id,
+    user: parseUser(review.user),
+    message: review.body || '',
+    state: review.state,
+    createdOn: review.submitted_at,
+    commit: review.commit_id
   };
 }
 


### PR DESCRIPTION
# Change Summary

 - assignees now populate the `assignees` attribute instead of the `reviewers` attribute on a `pullRequest`
 - integrated 2 new **github** `pull_request` events [resolves #29]
   - `review_requested` - adds a reviewer to the `pullRequest` data
   - `review_request_removed` - removes a reviewer and adds him to the history. history for removed reviewers is **not unique**. that's because the same reviewer can be removed multiple times
 - integrated 3 new **github** `pull_request_review_comment` events [resolves #29]
   - `created` - new review comment. add it to the `reviewComments` attribute.
   - `deleted` - deleted a review comment. removes it from the `reviewComments` attribute, and adds an history item inside `history.reviewComments.deleted` with the comment `id`
   - `edited` - changes the comment in `reviewComments`, and adds an history item inside `history.reviewComments[<comment_id>]` with the old message body
 - integrated 1 new **github** `pull_request_review` events [resolves #29]
   - `submitted` - reviewer submitted their review. this is populated in the `reviews` attribute. This holds all reviews by all users. reviews can't be changes, so every pull request review submits a new one and adds it to the array.
 
## More info

right now, pull request review comments **might appear twice!** once in `reviewComments` and once in `inlineComments`. So achievements that want to check all comments should go to `inlineComments` and ignore `reviewComments`. `reviewComments` should be used for achievements that focus on code reviews.

**tests will be implemented in a different PR**