### PR TITLE
add ssl redirect for heroku with NODE_ENV variable set to production

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var path = require('path');
 global.appRoot = path.resolve(__dirname);
 global.io = {};
 var scribe = require('scribe-js')();
+var sslRedirect = require('heroku-ssl-redirect');
 var express = require('express'); // call express
 var config = require('./config');
 var compression = require('compression');
@@ -19,6 +20,9 @@ var ngrok = require('ngrok');
 var console = require('./app/models/consoleService')();
 
 var app = express(); // define our app using express
+
+// enable ssl redirect
+app.use(sslRedirect());
 
 //Nunjucks setup
 nunjucks.configure('views', {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "gulp": "^3.9.1",
     "gulp-util": "^3.0.7",
     "helmet": "^3.1.0",
+    "heroku-ssl-redirect": "0.0.4",
     "http-auth": "^3.1.1",
     "js-schema": "^1.0.1",
     "lodash": "^4.16.6",


### PR DESCRIPTION
# Change Summary

 - Should redirect `http` to `https` on heroku
 > also added the `NODE_ENV` variable to heroku
