### PR TITLE
[FEATURE] add swagger documentation to api paths

### DIFF
--- a/app/routes/api.js
+++ b/app/routes/api.js
@@ -8,9 +8,48 @@ module.exports = function(app, express) {
 
   var apiRouter = express.Router();
 
+  /**
+   * @swagger
+   * /achievementsShield:
+   *   get:
+   *     summary: Generates an achievibit shield
+   *     description:
+   *       >
+   *         This will return an SVG file with the number of achievements
+   *         achievibit offers to add to markdown files
+   *     tags:
+   *       - Shield
+   *     responses:
+   *       200:
+   *         description: Number of achievements badge in SVG format
+   */
   apiRouter.route('/achievementsShield')
     .get(badgeService.get);
 
+  /**
+   * @swagger
+   * /authUsers:
+   *   get:
+   *     summary: Get authenticated user data
+   *     tags:
+   *       - User
+   *     responses:
+   *       200:
+   *         schema:
+   *           type: object
+   *           properties:
+   *             id:
+   *               type: integer
+   *             username:
+   *               type: string
+   *         examples:
+   *           application/json: {
+   *             "id": 1,
+   *             "username": "someuser"
+   *           }
+   *       409:
+   *         description: When the username is already in use
+   */
   apiRouter.route('/authUsers')
     .get(function(req, res) {
       var userParams = req.query;
@@ -21,20 +60,71 @@ module.exports = function(app, express) {
         userParams.githubUsername,
         userParams.timezone).then(function(data) {
         res.json({
-          achievibitUserData:
-            _.omit(data.newUser, ['_id', 'githubToken', 'uid'])
+          achievibitUserData: _.omit(data.newUser, [
+            '_id',
+            'githubToken',
+            'uid'
+          ])
         });
       }, function(error) {
         res.status(error.code).send(error.msg);
       });
     });
 
+  /**
+   * @swagger
+   * /createWebhook:
+   *   get:
+   *     summary: create an achievibit webhook for a GitHub authenticated user
+   *     tags:
+   *       - User
+   *     responses:
+   *       200:
+   *         schema:
+   *           type: object
+   *           properties:
+   *             id:
+   *               type: integer
+   *             username:
+   *               type: string
+   *         examples:
+   *           application/json: {
+   *             "id": 1,
+   *             "username": "someuser"
+   *           }
+   *       409:
+   *         description: When the username is already in use
+   */
   apiRouter.route('/createWebhook')
     .get(githubService.createWebhook);
 
   apiRouter.route('/sendFakeAchievementNotification/:username')
     .post(mockService.mockAchievementNotification);
 
+  /**
+   * @swagger
+   * /raw/{username}:
+   *   get:
+   *     summary: create an achievibit webhook for a GitHub authenticated user
+   *     tags:
+   *       - User
+   *     responses:
+   *       200:
+   *         schema:
+   *           type: object
+   *           properties:
+   *             id:
+   *               type: integer
+   *             username:
+   *               type: string
+   *         examples:
+   *           application/json: {
+   *             "id": 1,
+   *             "username": "someuser"
+   *           }
+   *       409:
+   *         description: When the username is already in use
+   */
   apiRouter.route('/raw/:username')
     .get(function(req, res) {
       var username = decodeURIComponent(req.params.username);
@@ -46,12 +136,37 @@ module.exports = function(app, express) {
       });
     });
 
+  /**
+   * @swagger
+   * /{username}:
+   *   get:
+   *     summary: create an achievibit webhook for a GitHub authenticated user
+   *     tags:
+   *       - User
+   *       - Raw Data
+   *     responses:
+   *       200:
+   *         schema:
+   *           type: object
+   *           properties:
+   *             id:
+   *               type: integer
+   *             username:
+   *               type: string
+   *         examples:
+   *           application/json: {
+   *             "id": 1,
+   *             "username": "someuser"
+   *           }
+   *       409:
+   *         description: When the username is already in use
+   */
   apiRouter.route('/:username')
     .get(function(req, res) {
       var username = decodeURIComponent(req.params.username);
 
       userService.getFullUser(username).then(function(data) {
-        res.render('blog' , data.pageData);
+        res.render('blog', data.pageData);
       }, function(error) {
         if (error.code === 301) {
           res.redirect(error.code, error.redirect);

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ var logo = require('./printLogo');
 var nunjucks = require('nunjucks');
 var _ = require('lodash');
 var ngrok = require('ngrok');
+var swaggerUi = require('swagger-ui-express');
+var swaggerJSDoc = require('swagger-jsdoc');
 
 // use scribe.js for logging
 var console = require('./app/models/consoleService')();
@@ -84,6 +86,36 @@ colors.enabled = true; //enable colors even through piping.
 
 // create application/json parser
 var jsonParser = bodyParser.json();
+
+/**  = ========================= =
+ *   = API DOCUMENTATION SWAGGER =
+ *   = ========================= =
+*/
+var spec = swaggerJSDoc({
+  swaggerDefinition: {
+    info: {
+      title: 'achievibit',
+      version: '1.0.0'
+    },
+    produces: [ 'application/json' ],
+    consumes: [ 'application/json' ],
+    securityDefinitions: {
+      jwt: {
+        type: 'apiKey',
+        name: 'Authorization',
+        in: 'header'
+      }
+    },
+    security: [
+      { jwt: [] }
+    ]
+  },
+  apis: [
+    'app/routes/*.js'
+  ]
+});
+
+app.use('/docs', swaggerUi.serve, swaggerUi.setup(spec));
 
 /** ===========
  *   = LOGGING =

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "./node_modules/.bin/nyc --reporter=html --reporter=text ./node_modules/.bin/mocha --reporter spec --reporter mochawesome",
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev": "node index.js --testDB",
+    "debug": "node --inspect index.js"
   },
   "repository": {
     "type": "git",
@@ -23,6 +25,7 @@
     "eslint-plugin-kibibit": "github:kibibit/eslint-plugin-kibibit",
     "eslint-plugin-lodash": "^2.3.3",
     "express": "^4.14.0",
+    "express-swagger-generator": "^1.0.4",
     "firebase-admin": "^5.1.0",
     "gh-badges": "^1.3.0",
     "gist-sync": "Thatkookooguy/gist-sync",
@@ -49,6 +52,8 @@
     "scribe-js": "Thatkookooguy/Scribe.js",
     "serve-favicon": "^2.3.0",
     "socket.io": "^2.0.3",
+    "swagger-jsdoc": "^1.9.7",
+    "swagger-ui-express": "^2.0.11",
     "tinycolor2": "^1.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
# Change Summary

 - add swagger documentation to api paths
   > you can go either to https://achievibit.kibibit.io/docs or `localhost:3141/docs` to see the docs. notice that the docs will not update until you restart your local server