### PR TITLE
Update contributing guidelines

### DIFF
--- a/CONTRIBUTING.MD
+++ b/CONTRIBUTING.MD
@@ -57,9 +57,5 @@ See [Supported Params](#supported-params) for more info
 
 # Running tests (WIP)
 
-`gulp test` will run
-- unit tests
-- REST-interface tests
-- clicktests.
-
-`gulp test:unittest` only runs the tests in the test/ folder, `gulp test:clicktest` runs only the tests in the clicktests/ folder. Install mocha (`npm install -g mocha`) to run specific tests in the test folder and get better stack traces: `mocha test/spec.git-api.js`.
+Run `npm test` to run unit tests.
+Install mocha (`npm install -g mocha`) to run specific tests in the test folder and get better stack traces: `mocha test/spec.git-api.js`.

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ if (!port) {
 
 var publicFolder = __dirname + '/public';
 
-var enableNgrok = privateConfig.ngrok || true;
+var enableNgrok = (privateConfig.ngrok === undefined) ? true : JSON.parse(privateConfig.ngrok);
 var token = privateConfig.ngrokToken;
 
 //TEMP HEADERS FOR ANGULAR 2 TEST

--- a/index.js
+++ b/index.js
@@ -53,7 +53,7 @@ if (!port) {
 
 var publicFolder = __dirname + '/public';
 
-var enableNgrok = privateConfig.ngrok;
+var enableNgrok = privateConfig.ngrok || true;
 var token = privateConfig.ngrokToken;
 
 //TEMP HEADERS FOR ANGULAR 2 TEST


### PR DESCRIPTION
# Change Summary
 
 I noticed a couple of improvement opportunities while working on #171. These are very small changes but they seemed to be out of scope for that PR

- The contributing guidelines specify to run the following command: `node index.js --databaseUrl " 
   <mongodb-url>" --ngrokToken "<ngrok-token>"` in order to start the application, but I had to run `node index.js --databaseUrl "<mongodb-url>" --ngrokToken "<ngrok-token>" --ngrok` (with the --ngrok flag) in order to actually get ngrok to work and get the URL

    Since it doesn't feel like requiring the `--ngrok` flag is the desired behavior, I added additional logic to default the `enableNgrok` variable to `true`, while keeping the value if it exists. User can still disable ngrok by running the command `--ngrok false` -- I'm not sure what the use of this is, but since the `enableNgrok` is used throughout the file, I kept the ability to disable it.

- The contributing guidelines seem to be outdated for the tests script, so I updated it to just use `npm test`

