### PR TITLE
Feature/move sorting imports to eslint

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -27,19 +27,19 @@
     "bracketPairColorizer.forceUniqueOpeningColor": true,
     "bracketPairColorizer.showBracketsInGutter": true,
     "window.title": "${activeEditorShort}${separator}${rootName} [kibibit]",
-    "typescriptHero.imports.stringQuoteStyle": "'",
-    "typescriptHero.imports.grouping": [
-      "Plains",
-      "Modules",
-      "/^@kb-/",
-      "Workspace"
+    // "typescriptHero.imports.stringQuoteStyle": "'",
+    // "typescriptHero.imports.grouping": [
+    //   "Plains",
+    //   "Modules",
+    //   "/^@kb-/",
+    //   "Workspace"
 
-    ],
-    "typescriptHero.imports.organizeOnSave": true,
-    "typescriptHero.imports.multiLineTrailingComma": false,
-    "typescriptHero.imports.multiLineWrapThreshold": 80,
-    "typescriptHero.imports.insertSpaceBeforeAndAfterImportBraces": true,
-    "typescriptHero.imports.insertSemicolons": true,
+    // ],
+    // "typescriptHero.imports.organizeOnSave": true,
+    // "typescriptHero.imports.multiLineTrailingComma": false,
+    // "typescriptHero.imports.multiLineWrapThreshold": 80,
+    // "typescriptHero.imports.insertSpaceBeforeAndAfterImportBraces": true,
+    // "typescriptHero.imports.insertSemicolons": true,
     "editor.codeActionsOnSave": {
       "source.fixAll.eslint": true,
     },
@@ -54,7 +54,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
-		"rbbit.typescript-hero",
+		// "rbbit.typescript-hero",
 		"coenraads.bracket-pair-colorizer",
 		"orta.vscode-jest",
 		"wix.vscode-import-cost",

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,6 @@
 {
   "recommendations": [
-    "rbbit.typescript-hero",
+    // "rbbit.typescript-hero",
     "coenraads.bracket-pair-colorizer",
     "wix.vscode-import-cost",
     "orta.vscode-jest",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8362,6 +8362,19 @@
       "integrity": "sha1-nlKHYrSpBmrRY6aWKjZEGOlibs4=",
       "dev": true
     },
+    "array-includes": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/array-includes/-/array-includes-3.1.3.tgz",
+      "integrity": "sha512-gcem1KlBU7c9rB+Rq8/3PPKsK2kjqeEBa3bD5kkQo4nYlOHQCJqIJFqBXDEfwaRuYTT4E+FxA9xez7Gf/e3Q7A==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.2",
+        "get-intrinsic": "^1.1.1",
+        "is-string": "^1.0.5"
+      }
+    },
     "array-union": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
@@ -8379,6 +8392,17 @@
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
       "integrity": "sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=",
       "dev": true
+    },
+    "array.prototype.flat": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flat/-/array.prototype.flat-1.2.4.tgz",
+      "integrity": "sha512-4470Xi3GAPAjZqFcljX2xzckv1qeKPizoNkiS0+O4IoPR2ZNpcjE0pkhdihlDouK+x6QOast26B4Q/O9DJnwSg==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.0",
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.18.0-next.1"
+      }
     },
     "arraybuffer.slice": {
       "version": "0.0.7",
@@ -11113,6 +11137,12 @@
       "integrity": "sha1-wguW2MYXdIqvHBYCF2DNJ/y4y3U=",
       "dev": true
     },
+    "contains-path": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/contains-path/-/contains-path-0.1.0.tgz",
+      "integrity": "sha1-/ozxhP9mcLa67wGp1IYaXL7EEgo=",
+      "dev": true
+    },
     "content-disposition": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.3.tgz",
@@ -13313,6 +13343,195 @@
           }
         }
       }
+    },
+    "eslint-import-resolver-node": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "resolve": "^1.13.1"
+      }
+    },
+    "eslint-module-utils": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.6.0.tgz",
+      "integrity": "sha512-6j9xxegbqe8/kZY8cYpcp0xhbK0EgJlg3g9mib3/miLaExuuwc3n5UEfSnU6hWMbT0FAYVvDbL9RrRgpUeQIvA==",
+      "dev": true,
+      "requires": {
+        "debug": "^2.6.9",
+        "pkg-dir": "^2.0.0"
+      }
+    },
+    "eslint-plugin-import": {
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
+      "dev": true,
+      "requires": {
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
+        "contains-path": "^0.1.0",
+        "debug": "^2.6.9",
+        "doctrine": "1.5.0",
+        "eslint-import-resolver-node": "^0.3.4",
+        "eslint-module-utils": "^2.6.0",
+        "has": "^1.0.3",
+        "minimatch": "^3.0.4",
+        "object.values": "^1.1.1",
+        "read-pkg-up": "^2.0.0",
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
+      },
+      "dependencies": {
+        "doctrine": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
+          "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
+          "dev": true,
+          "requires": {
+            "esutils": "^2.0.2",
+            "isarray": "^1.0.0"
+          }
+        },
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "normalize-package-data": {
+          "version": "2.5.0",
+          "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.5.0.tgz",
+          "integrity": "sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^2.1.4",
+            "resolve": "^1.10.0",
+            "semver": "2 || 3 || 4 || 5",
+            "validate-npm-package-license": "^3.0.1"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
+        "semver": {
+          "version": "5.7.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "dev": true
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        }
+      }
+    },
+    "eslint-plugin-simple-import-sort": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
+      "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -23060,6 +23279,66 @@
       "requires": {
         "find-up": "^2.0.0",
         "load-json-file": "^4.0.0"
+      },
+      "dependencies": {
+        "find-up": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
+          "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
+          "dev": true,
+          "requires": {
+            "locate-path": "^2.0.0"
+          }
+        },
+        "locate-path": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
+          "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
+          "dev": true,
+          "requires": {
+            "p-locate": "^2.0.0",
+            "path-exists": "^3.0.0"
+          }
+        },
+        "p-limit": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+          "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
+          "dev": true,
+          "requires": {
+            "p-try": "^1.0.0"
+          }
+        },
+        "p-locate": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
+          "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
+          "dev": true,
+          "requires": {
+            "p-limit": "^1.1.0"
+          }
+        },
+        "p-try": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/p-try/-/p-try-1.0.0.tgz",
+          "integrity": "sha1-y8ec26+P1CKOE/Yh8rGiN8GyB7M=",
+          "dev": true
+        },
+        "path-exists": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-3.0.0.tgz",
+          "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=",
+          "dev": true
+        }
+      }
+    },
+    "pkg-dir": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-2.0.0.tgz",
+      "integrity": "sha1-9tXREJ4Z1j7fQo4L1X4Sd3YVM0s=",
+      "dev": true,
+      "requires": {
+        "find-up": "^2.1.0"
       },
       "dependencies": {
         "find-up": {

--- a/package.json
+++ b/package.json
@@ -80,6 +80,8 @@
     "cz-conventional-changelog": "^3.3.0",
     "cz-conventional-changelog-emoji": "^0.1.0",
     "eslint": "^7.19.0",
+    "eslint-plugin-import": "^2.22.1",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "foswig": "^3.0.1",
     "github-username": "^6.0.0",
     "gitlog": "^4.0.4",

--- a/server/.eslintrc.js
+++ b/server/.eslintrc.js
@@ -4,7 +4,11 @@ module.exports = {
     project: 'tsconfig.json',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint/eslint-plugin'],
+  plugins: [
+    '@typescript-eslint/eslint-plugin',
+    'simple-import-sort',
+    'import'
+  ],
   extends: [
     'plugin:@typescript-eslint/eslint-recommended',
     'plugin:@typescript-eslint/recommended',
@@ -19,6 +23,30 @@ module.exports = {
     jest: true,
   },
   rules: {
+    'simple-import-sort/imports': ['error', {
+      groups: [
+        // 1. built-in node.js modules
+        [`^(${require("module").builtinModules.join("|")})(/|$)`],
+        // 2.1. package that start without @
+        // 2.2. package that start with @ 
+        ['^\\w', '^@\\w'],
+        // 3. @nestjs packages
+        ['^@nestjs\/'],
+        // 4. @kibibit external packages
+        ['^@kibibit\/'],
+        // 5. Internal kibibit packages (inside this project)
+        ['^@kb-'],
+        // 6. Parent imports. Put `..` last.
+        //    Other relative imports. Put same-folder imports and `.` last.
+        ["^\\.\\.(?!/?$)", "^\\.\\./?$", "^\\./(?=.*/)(?!/?$)", "^\\.(?!/?$)", "^\\./?$"],
+        // 7. Side effect imports.
+        // https://riptutorial.com/javascript/example/1618/importing-with-side-effects
+        ["^\\u0000"]
+      ]
+    }],
+    'import/first': 'error',
+    'import/newline-after-import': 'error',
+    'import/no-duplicates': 'error',
     'eol-last': [ 2, 'windows' ],
     'comma-dangle': [ 'error', 'never' ],
     'max-len': [ 'error', { 'code': 80, "ignoreComments": true } ],
@@ -37,6 +65,8 @@ module.exports = {
           "match": true
         }
       }
-    ]
+    ],
+    "semi": "off",
+    "@typescript-eslint/semi": ["error"]
   }
 };

--- a/server/src/abstracts/base.model.abstract.ts
+++ b/server/src/abstracts/base.model.abstract.ts
@@ -1,6 +1,6 @@
-import { buildSchema, prop as PersistInDb } from '@typegoose/typegoose';
 import { classToPlain, Exclude, Expose } from 'class-transformer';
 import { Schema } from 'mongoose';
+import { buildSchema, prop as PersistInDb } from '@typegoose/typegoose';
 
 @Exclude()
 export abstract class BaseModel {

--- a/server/src/abstracts/base.service.abstract.ts
+++ b/server/src/abstracts/base.service.abstract.ts
@@ -1,8 +1,9 @@
-import { InternalServerErrorException } from '@nestjs/common';
-import { DocumentType, ReturnModelType } from '@typegoose/typegoose';
-import { AnyParamConstructor } from '@typegoose/typegoose/lib/types';
 import { MongoError } from 'mongodb';
 import { Document, DocumentQuery, Query, Types } from 'mongoose';
+import { DocumentType, ReturnModelType } from '@typegoose/typegoose';
+import { AnyParamConstructor } from '@typegoose/typegoose/lib/types';
+
+import { InternalServerErrorException } from '@nestjs/common';
 
 import { BaseModel } from './base.model.abstract';
 

--- a/server/src/api/api.controller.spec.ts
+++ b/server/src/api/api.controller.spec.ts
@@ -1,6 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import findRoot from 'find-root';
 import fs from 'fs-extra';
+
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { ApiController } from '@kb-api';
 import { ConfigService } from '@kb-config';

--- a/server/src/api/api.controller.ts
+++ b/server/src/api/api.controller.ts
@@ -1,8 +1,10 @@
-import { Controller, Get, Logger } from '@nestjs/common';
-import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
+import { join } from 'path';
+
 import { readJSON } from 'fs-extra';
 import { chain } from 'lodash';
-import { join } from 'path';
+
+import { Controller, Get, Logger } from '@nestjs/common';
+import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
 
 import { ConfigService } from '@kb-config';
 import { ApiInfo } from '@kb-models';

--- a/server/src/api/api.module.ts
+++ b/server/src/api/api.module.ts
@@ -6,13 +6,13 @@ import { ConfigModule, ConfigService } from '@kb-config';
 import {
   createInMemoryDatabaseModule
 } from '../dev-tools/in-memory-database.module';
-import { ApiController } from './api.controller';
 import { PullRequestModule } from './pull-request/pull-request.module';
 import { RepoModule } from './repo/repo.module';
 import { UserModule } from './user/user.module';
 import {
   WebhookEventManagerModule
 } from './webhook-event-manager/webhook-event-manager.module';
+import { ApiController } from './api.controller';
 
 const config = new ConfigService();
 @Module({

--- a/server/src/api/pull-request/pull-request.controller.spec.ts
+++ b/server/src/api/pull-request/pull-request.controller.spec.ts
@@ -1,5 +1,6 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { noop } from 'lodash';
+
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { PullRequestController } from './pull-request.controller';
 import { PullRequestService } from './pull-request.service';

--- a/server/src/api/pull-request/pull-request.service.ts
+++ b/server/src/api/pull-request/pull-request.service.ts
@@ -1,6 +1,7 @@
+import { ReturnModelType } from '@typegoose/typegoose';
+
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { ReturnModelType } from '@typegoose/typegoose';
 
 import { BaseService } from '@kb-abstracts';
 import { IGithubChanges } from '@kb-interfaces';

--- a/server/src/api/repo/repo.controller.spec.ts
+++ b/server/src/api/repo/repo.controller.spec.ts
@@ -1,5 +1,6 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { noop } from 'lodash';
+
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { RepoService } from '@kb-api';
 import { DtoMockGenerator } from '@kb-dev-tools';

--- a/server/src/api/repo/repo.service.spec.ts
+++ b/server/src/api/repo/repo.service.spec.ts
@@ -87,7 +87,7 @@ describe('RepoService', () => {
     const allRepos = await service.findAllRepos();
     expect(allRepos.length).toBe(1);
     expect(allRepos[0]).toEqual(expect.objectContaining(createdRepo));
-    expect(allRepos[0]._id).toBeDefined()
+    expect(allRepos[0]._id).toBeDefined();
     expect(allRepos[0]._id).toEqual(createdRepo._id);
   });
 });

--- a/server/src/api/repo/repo.service.ts
+++ b/server/src/api/repo/repo.service.ts
@@ -1,6 +1,7 @@
+import { ReturnModelType } from '@typegoose/typegoose';
+
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { ReturnModelType } from '@typegoose/typegoose';
 
 import { BaseService } from '@kb-abstracts';
 import { Repo } from '@kb-models';

--- a/server/src/api/user/user.controller.spec.ts
+++ b/server/src/api/user/user.controller.spec.ts
@@ -1,5 +1,6 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { noop } from 'lodash';
+
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { DtoMockGenerator } from '@kb-dev-tools';
 

--- a/server/src/api/user/user.service.spec.ts
+++ b/server/src/api/user/user.service.spec.ts
@@ -103,7 +103,7 @@ describe('UserService', () => {
     const allUsers = await service.findAllUsers();
     expect(allUsers.length).toBe(1);
     expect(allUsers[0]).toEqual(expect.objectContaining(createdUser));
-    expect(allUsers[0]._id).toBeDefined()
+    expect(allUsers[0]._id).toBeDefined();
     expect(allUsers[0]._id).toEqual(createdUser._id);
   });
 });

--- a/server/src/api/user/user.service.ts
+++ b/server/src/api/user/user.service.ts
@@ -1,6 +1,7 @@
+import { ReturnModelType } from '@typegoose/typegoose';
+
 import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { ReturnModelType } from '@typegoose/typegoose';
 
 import { BaseService } from '@kb-abstracts';
 import { User } from '@kb-models';

--- a/server/src/api/webhook-event-manager/webhook-event-manager.service.ts
+++ b/server/src/api/webhook-event-manager/webhook-event-manager.service.ts
@@ -1,5 +1,6 @@
-import { Injectable, Logger } from '@nestjs/common';
 import { isEqual } from 'lodash';
+
+import { Injectable, Logger } from '@nestjs/common';
 
 import { AchievibitEventNames } from '@kb-abstracts';
 import { GithubEngine } from '@kb-engines';

--- a/server/src/app/app.controller.spec.ts
+++ b/server/src/app/app.controller.spec.ts
@@ -1,5 +1,6 @@
-import { Test, TestingModule } from '@nestjs/testing';
 import { mockResponse } from 'jest-mock-req-res';
+
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { AppController } from '@kb-app';
 import { ConfigModule } from '@kb-config';

--- a/server/src/app/app.controller.ts
+++ b/server/src/app/app.controller.ts
@@ -1,7 +1,9 @@
+import { join } from 'path';
+
+import { Response } from 'express';
+
 import { Controller, Get, Res } from '@nestjs/common';
 import { ApiOkResponse, ApiOperation } from '@nestjs/swagger';
-import { Response } from 'express';
-import { join } from 'path';
 
 import { ConfigService } from '@kb-config';
 

--- a/server/src/bootstrap-application.ts
+++ b/server/src/bootstrap-application.ts
@@ -1,9 +1,11 @@
-import { terminalConsoleLogo } from '@kibibit/consologo';
+import { join } from 'path';
+
 import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { NestExpressApplication } from '@nestjs/platform-express';
 import { WsAdapter } from '@nestjs/platform-ws';
-import { join } from 'path';
+
+import { terminalConsoleLogo } from '@kibibit/consologo';
 
 import { AppModule } from '@kb-app';
 import { ConfigService } from '@kb-config';
@@ -19,7 +21,7 @@ export async function bootstrap(): Promise<NestExpressApplication> {
     'change this in server/src/bootstrap-application.ts'
   ]);
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
-  app.useWebSocketAdapter(new WsAdapter(app))
+  app.useWebSocketAdapter(new WsAdapter(app));
   app.useGlobalFilters(new KbNotFoundExceptionFilter(appRoot));
   app.useGlobalPipes(new ValidationPipe());
   app.useStaticAssets(join(appRoot, './dist/client'));

--- a/server/src/config/config.service.ts
+++ b/server/src/config/config.service.ts
@@ -1,4 +1,5 @@
-import { Logger } from '@nestjs/common';
+import { join } from 'path';
+
 import { classToPlain, Exclude } from 'class-transformer';
 import { validateSync } from 'class-validator';
 import findRoot from 'find-root';
@@ -10,8 +11,9 @@ import {
 } from 'fs-extra';
 import { camelCase, get } from 'lodash';
 import nconf from 'nconf';
-import { join } from 'path';
 import SmeeClient from 'smee-client';
+
+import { Logger } from '@nestjs/common';
 
 import { ConfigValidationError } from '@kb-errors';
 import { ApiInfo } from '@kb-models';

--- a/server/src/decorators/task-health-check.decorator.ts
+++ b/server/src/decorators/task-health-check.decorator.ts
@@ -14,10 +14,10 @@ export const TaskHealthCheck = function (healthCheckId?: string) {
       if (healthCheckId) {
         await pingHealthCheck(healthCheckId);
       }
-    }
+    };
 
     return descriptor;
-  }
+  };
 };
 
 async function pingHealthCheck(healthCheckId: string) {

--- a/server/src/dev-tools/common-mocks.ts
+++ b/server/src/dev-tools/common-mocks.ts
@@ -1,7 +1,8 @@
+import { Exclude, Expose } from 'class-transformer';
+import { prop as PersistInDb, ReturnModelType } from '@typegoose/typegoose';
+
 import { ArgumentsHost, Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
-import { prop as PersistInDb, ReturnModelType } from '@typegoose/typegoose';
-import { Exclude, Expose } from 'class-transformer';
 
 import { BaseModel, BaseService } from '@kb-abstracts';
 
@@ -17,7 +18,7 @@ export const mockResponse = {
 };
 
 export const hostMock = (req, res, roles?: string[]): ArgumentsHost => {
-  const ctx: any = {}
+  const ctx: any = {};
   ctx.switchToHttp = jest.fn().mockReturnValue({
       getRequest: () => req,
       getResponse: () => res

--- a/server/src/dev-tools/dto.mock-generator.ts
+++ b/server/src/dev-tools/dto.mock-generator.ts
@@ -78,7 +78,7 @@ const customMixin: IChanceMixin & Chance.MixinDescriptor = {
       number: chance.integer(),
       prid: chance.guid(),
       url: chance.url()
-    })
+    });
   },
   achievementScripts(
     numOfAchievements: number = chance.integer({ min: 1, max: 25 })

--- a/server/src/dev-tools/in-memory-database.module.ts
+++ b/server/src/dev-tools/in-memory-database.module.ts
@@ -1,6 +1,7 @@
-import { MongooseModule, MongooseModuleOptions } from '@nestjs/mongoose';
 import { MongoMemoryServer } from 'mongodb-memory-server';
 import mongoose from 'mongoose';
+
+import { MongooseModule, MongooseModuleOptions } from '@nestjs/mongoose';
 
 let mongod: MongoMemoryServer;
 
@@ -12,11 +13,11 @@ export const createInMemoryDatabaseModule =
       return {
         uri: mongoUri,
         ...options
-      }
+      };
     }
   });
 
 export const closeInMemoryDatabaseConnection = async () => {
   await mongoose.disconnect();
   if (mongod) await mongod.stop();
-}
+};

--- a/server/src/events/events.gateway.ts
+++ b/server/src/events/events.gateway.ts
@@ -1,3 +1,7 @@
+import { from, Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
+import { Server } from 'socket.io';
+
 import { Logger } from '@nestjs/common';
 import {
   MessageBody,
@@ -7,9 +11,6 @@ import {
   WebSocketServer,
   WsResponse
 } from '@nestjs/websockets';
-import { from, Observable } from 'rxjs';
-import { map } from 'rxjs/operators';
-import { Server } from 'socket.io';
 
 @WebSocketGateway()
 export class EventsGateway implements OnGatewayConnection {

--- a/server/src/events/events.module.ts
+++ b/server/src/events/events.module.ts
@@ -1,4 +1,5 @@
 import { Module } from '@nestjs/common';
+
 import { EventsGateway } from './events.gateway';
 
 @Module({

--- a/server/src/filters/kb-not-found-exception.filter.spec.ts
+++ b/server/src/filters/kb-not-found-exception.filter.spec.ts
@@ -6,7 +6,7 @@ import { KbNotFoundExceptionFilter } from '@kb-filters';
 describe('NotFoundExceptionFilterFilter', () => {
   beforeEach(() => {
     mockResponse.mockClear();
-  })
+  });
 
   it('should be defined', () => {
     expect(new KbNotFoundExceptionFilter('')).toBeDefined();

--- a/server/src/filters/kb-not-found-exception.filter.ts
+++ b/server/src/filters/kb-not-found-exception.filter.ts
@@ -1,10 +1,11 @@
+import { join } from 'path';
+
 import {
   ArgumentsHost,
   Catch,
   ExceptionFilter,
   NotFoundException
 } from '@nestjs/common';
-import { join } from 'path';
 
 @Catch(NotFoundException)
 export class KbNotFoundExceptionFilter implements ExceptionFilter {

--- a/server/src/filters/kb-validation-exception.filter.spec.ts
+++ b/server/src/filters/kb-validation-exception.filter.spec.ts
@@ -1,5 +1,6 @@
-import { BadRequestException, HttpStatus } from '@nestjs/common';
 import MockDate from 'mockdate';
+
+import { BadRequestException, HttpStatus } from '@nestjs/common';
 
 import { hostMock, mockResponse } from '@kb-dev-tools';
 import { KbValidationExceptionFilter } from '@kb-filters';

--- a/server/src/models/pull-request.model.ts
+++ b/server/src/models/pull-request.model.ts
@@ -1,12 +1,13 @@
-import { ApiProperty } from '@nestjs/swagger';
+import { Exclude, Expose } from 'class-transformer';
+import { IsNumber, IsOptional, IsString } from 'class-validator';
 import {
   index,
   modelOptions,
   prop as PersistInDb,
   Severity
 } from '@typegoose/typegoose';
-import { Exclude, Expose } from 'class-transformer';
-import { IsNumber, IsOptional, IsString } from 'class-validator';
+
+import { ApiProperty } from '@nestjs/swagger';
 
 import { BaseModel } from '../abstracts/base.model.abstract';
 

--- a/server/src/models/repo.model.ts
+++ b/server/src/models/repo.model.ts
@@ -1,7 +1,8 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { index, modelOptions, prop as PersistInDb } from '@typegoose/typegoose';
 import { Exclude, Expose } from 'class-transformer';
 import { IsNotEmpty, IsOptional, IsString } from 'class-validator';
+import { index, modelOptions, prop as PersistInDb } from '@typegoose/typegoose';
+
+import { ApiProperty } from '@nestjs/swagger';
 
 import { BaseModel } from '@kb-abstracts';
 

--- a/server/src/models/user.model.ts
+++ b/server/src/models/user.model.ts
@@ -1,10 +1,3 @@
-import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
-import {
-  index,
-  modelOptions,
-  prop as PersistInDb,
-  Severity
-} from '@typegoose/typegoose';
 import { Exclude, Expose } from 'class-transformer';
 import {
   IsArray,
@@ -13,6 +6,13 @@ import {
   IsOptional,
   IsString
 } from 'class-validator';
+import {
+  index,
+  modelOptions,prop as PersistInDb,
+  Severity
+} from '@typegoose/typegoose';
+
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
 
 import { BaseModel } from '@kb-abstracts';
 

--- a/server/src/swagger.ts
+++ b/server/src/swagger.ts
@@ -1,6 +1,7 @@
+import axios from 'axios';
+
 import { INestApplication } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
-import axios from 'axios';
 
 import { ConfigService } from '@kb-config';
 
@@ -74,7 +75,7 @@ export class Swagger {
       }
 
       return result;
-    }
+    };
   }
 
   static async addSwagger(app: INestApplication) {

--- a/server/src/tasks/tasks.service.spec.ts
+++ b/server/src/tasks/tasks.service.spec.ts
@@ -1,6 +1,7 @@
+import MockDate from 'mockdate';
+
 import { MongooseModule } from '@nestjs/mongoose';
 import { Test, TestingModule } from '@nestjs/testing';
-import MockDate from 'mockdate';
 
 import { PullRequestService } from '@kb-api';
 import {

--- a/server/test/app.e2e-spec.ts
+++ b/server/test/app.e2e-spec.ts
@@ -1,7 +1,8 @@
-import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import { valid } from 'semver';
 import request from 'supertest';
+
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { AppModule } from '@kb-app';
 

--- a/server/test/github-events.e2e-spec.ts
+++ b/server/test/github-events.e2e-spec.ts
@@ -1,7 +1,8 @@
-import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { PullRequestService } from '@kb-api';
 import { AppModule } from '@kb-app';

--- a/server/test/sockets.e2e-spec.ts
+++ b/server/test/sockets.e2e-spec.ts
@@ -1,6 +1,7 @@
-import { Test, TestingModule } from '@nestjs/testing';
-import { observe } from 'rxjs-marbles/jest';
 import { take, tap } from 'rxjs/operators';
+import { observe } from 'rxjs-marbles/jest';
+
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { AppModule } from '@kb-app';
 

--- a/server/test/tasks.e2e-spec.ts
+++ b/server/test/tasks.e2e-spec.ts
@@ -1,8 +1,9 @@
-import { INestApplication } from '@nestjs/common';
-import { Test, TestingModule } from '@nestjs/testing';
 import MockDate from 'mockdate';
 import mongoose from 'mongoose';
 import request from 'supertest';
+
+import { INestApplication } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
 
 import { PullRequestService } from '@kb-api';
 import { AppModule } from '@kb-app';

--- a/server/test/utils.ts
+++ b/server/test/utils.ts
@@ -1,7 +1,8 @@
-import { INestApplication } from '@nestjs/common/interfaces';
-import { TestingModule } from '@nestjs/testing/testing-module';
 import * as bodyParser from 'body-parser';
 import express from 'express';
+
+import { INestApplication } from '@nestjs/common/interfaces';
+import { TestingModule } from '@nestjs/testing/testing-module';
 
 import { SocketService } from './socket.service';
 


### PR DESCRIPTION
### Description

- Added `eslint-plugin-import` for rules
   - `import/first`: makes sure all imports are at the top of the file. **(autofixable)**
   - `import/newline-after-import`: makes sure there’s a newline after the imports. **(autofixable)**
   - `import/no-duplicates`: merges import statements of the same file. **(autofixable, mostly)**
- Added `eslint-plugin-simple-import-sort` for rules
   - `simple-import-sort/imports`: sort imports in groups. **(autofixable)**
 - Made sure `semi` is turned off and enabled the rule `@typescript-eslint/semi` in order to enforce that **(autofixable)**
 - Comment out `TypeScript Hero` vscode extension for now since this was replaced with this eslint plugins.
   > I still need to test that everything with these plugins work correctly, So I'm starting with **commenting
      those lines out**, and after a grace period, we'll remove those comments as well
 - **AND....** `lint:fix` all the files in the last commit of this pull request

### Checklist
Please check if your PR fulfills the following requirements:
- [x] Code compiles correctly (`npm run build`)
- [x] Code is linted
- [x] Created tests which fail without the change (if possible) 
- All **relevant** tests are passing
  - [x] Server Unit Tests
  - [x] Client Unit Tests
  - [x] Achievements Unit Tests
  - [x] API Tests
  - [x] E2E Tests
- [x] Extended the README / documentation, if necessary
