### PR TITLE
ci(github): allow comments on forks by linter

### DIFF
--- a/.github/workflows/lint-achievements.yml
+++ b/.github/workflows/lint-achievements.yml
@@ -2,7 +2,10 @@ name: Lint Achievements
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request: # Run on local PRs
+    paths:
+    - 'achievements/**'
+  pull_request_target: # Run on fork PRs
     paths:
     - 'achievements/**'
   push:

--- a/.github/workflows/lint-server.yml
+++ b/.github/workflows/lint-server.yml
@@ -2,7 +2,10 @@ name: Lint Server
 
 on:
   workflow_dispatch:
-  pull_request:
+  pull_request: # Run on local PRs
+    paths:
+    - 'server/**'
+  pull_request_target: # Run on fork PRs
     paths:
     - 'server/**'
   push:


### PR DESCRIPTION
### Description
- Allow lint comments on forks
  > Support pull_request_target event to allow commenting on PRs from forks